### PR TITLE
Fix path to index.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "ephoton <i@ephoton.me> (https://github.com/ephoton)",
     "chenshuai2144 <qixian.cs@outlook.com> (https://github.com/chenshuai2144)"
   ],
-  "main": "build/src/index.js",
-  "typings": "build/src/index.d.ts",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
With the latest version of npm, I do not succeed to import the library.
I obtain this error:

`Cannot find module '/app/node_modules/@umijs/linguist/build/src/index.js'. Please verify that the package.json has a valid "main" entry`

This fix resolve the issue.
